### PR TITLE
Comics finder

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,8 @@
 build:
 	@go build -C cmd/xkcd -o "../../xkcd"
 
+test:
+	@go test -bench=. -v ./cmd/xkcd/
+
 clean:
-	rm xkcd
+	@rm xkcd

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 build:
-	@go build -o "xkcd" cmd/xkcd/main.go
+	@go build -C cmd/xkcd -o "../../xkcd"
 
 clean:
 	rm xkcd

--- a/cmd/xkcd/config.go
+++ b/cmd/xkcd/config.go
@@ -1,0 +1,49 @@
+package main
+
+import (
+	"gopkg.in/yaml.v3"
+	"os"
+)
+
+type Config struct {
+	SourceUrl string `yaml:"source_url"`
+	DBFile    string `yaml:"db_file"`
+}
+
+func newConfig(configPath string) (*Config, error) {
+	config := &Config{}
+
+	file, err := os.Open(configPath)
+	if err != nil {
+		return nil, err
+	}
+	defer func(file *os.File) {
+		_ = file.Close()
+	}(file)
+
+	d := yaml.NewDecoder(file)
+	if err = d.Decode(&config); err != nil {
+		return nil, err
+	}
+
+	return config, nil
+}
+
+func getGoroutinesNum() (int, error) {
+	defaultValue := 500
+	obj := make(map[string]int)
+
+	yamlFile, err := os.ReadFile("parallel")
+	if err != nil {
+		return defaultValue, err
+	}
+	err = yaml.Unmarshal(yamlFile, obj)
+	if err != nil {
+		return defaultValue, err
+	}
+
+	if obj["goroutines"] == 0 {
+		obj["goroutines"] = defaultValue
+	}
+	return obj["goroutines"], nil
+}

--- a/cmd/xkcd/fillMissedComics.go
+++ b/cmd/xkcd/fillMissedComics.go
@@ -1,0 +1,95 @@
+package main
+
+import (
+	"courses/internal/core"
+	"courses/internal/database"
+	"courses/internal/xkcd"
+	"courses/pkg/words"
+	"log"
+	"os"
+	"os/signal"
+	"sync"
+	"syscall"
+)
+
+func fillMissedComics(goroutineNum int, comics map[int]core.ComicsDescript,
+	db database.DataBase, downloader xkcd.ComicsDownloader) (map[int]core.ComicsDescript, error) {
+
+	comicsIDChan := make(chan int, goroutineNum)
+	comicsChan := make(chan comicsDescriptWithID, goroutineNum)
+	wg := sync.WaitGroup{}
+	var mt sync.Mutex
+
+	sigs := make(chan os.Signal, 1)
+	signal.Notify(sigs, syscall.SIGINT, syscall.SIGTERM)
+
+	// launch worker pool
+	for range goroutineNum {
+		wg.Add(1)
+		go func() {
+			worker(downloader, comics, comicsIDChan, comicsChan, &mt)
+			wg.Done()
+		}()
+	}
+
+	var curComics comicsDescriptWithID
+	// download comics till no error
+	for i := 1; ; i++ {
+		// send in advance bunch of ID to optimize downloading
+		if i%goroutineNum == 1 {
+			for j := i; j < i+goroutineNum; j++ {
+				comicsIDChan <- j
+			}
+		}
+
+		curComics = <-comicsChan
+		if curComics.Url != "" && len(sigs) == 0 {
+			if err := writeComicsWithID(curComics, &db); err != nil {
+				return comics, err
+			}
+		} else {
+			close(comicsIDChan)
+			wg.Wait()
+			close(comicsChan)
+
+			for range len(comicsChan) {
+				curComics = <-comicsChan
+				if curComics.Url == "" {
+					continue
+				}
+				if err := writeComicsWithID(curComics, &db); err != nil {
+					return comics, err
+				}
+			}
+			break
+		}
+	}
+	return comics, nil
+}
+
+func worker(downloader xkcd.ComicsDownloader, comics map[int]core.ComicsDescript, comicsIDChan <-chan int,
+	results chan<- comicsDescriptWithID, mt *sync.Mutex) {
+	for comID := range comicsIDChan {
+		if comics[comID].Keywords == nil {
+			descript, id, err := downloader.GetComicsFromID(comID)
+			if err != nil {
+				log.Println(err)
+				results <- comicsDescriptWithID{id: comID}
+				continue
+			}
+			descript.Keywords = words.StemStringWithClearing(descript.Keywords)
+			results <- comicsDescriptWithID{id: id, ComicsDescript: descript}
+			mt.Lock()
+			comics[id] = descript
+			mt.Unlock()
+			continue
+		}
+		results <- comicsDescriptWithID{id: comID, ComicsDescript: comics[comID]}
+	}
+}
+
+func writeComicsWithID(comicsWID comicsDescriptWithID, db *database.DataBase) error {
+	var comics = make(map[int]core.ComicsDescript)
+	comics[comicsWID.id] = comicsWID.ComicsDescript
+	return db.Write(comics)
+}

--- a/cmd/xkcd/find.go
+++ b/cmd/xkcd/find.go
@@ -15,7 +15,9 @@ func findByComics(comics map[int]core.ComicsDescript, input []string) []goodComi
 				numOfWords++
 			}
 		}
-		res = append(res, goodComics{id: id, numOfKeywords: numOfWords})
+		if numOfWords != 0 {
+			res = append(res, goodComics{id: id, numOfKeywords: numOfWords})
+		}
 	}
 	slices.SortFunc(res, func(a, b goodComics) int {
 		return cmp.Compare(a.numOfKeywords, b.numOfKeywords) * (-1)
@@ -32,7 +34,9 @@ func findByIndex(index map[string][]int, input []string) []goodComics {
 	}
 	var res []goodComics
 	for k, v := range wasFound {
-		res = append(res, goodComics{id: k, numOfKeywords: v})
+		if v != 0 {
+			res = append(res, goodComics{id: k, numOfKeywords: v})
+		}
 	}
 	slices.SortFunc(res, func(a, b goodComics) int {
 		return cmp.Compare(a.numOfKeywords, b.numOfKeywords) * (-1)

--- a/cmd/xkcd/find.go
+++ b/cmd/xkcd/find.go
@@ -40,7 +40,6 @@ func findByIndex(index map[string][]int, input []string) []goodComics {
 	return res
 }
 
-// TODO: descript
 type goodComics struct {
 	id            int
 	numOfKeywords int

--- a/cmd/xkcd/find.go
+++ b/cmd/xkcd/find.go
@@ -1,0 +1,47 @@
+package main
+
+import (
+	"cmp"
+	"courses/internal/core"
+	"slices"
+)
+
+func findByComics(comics map[int]core.ComicsDescript, input []string) []goodComics {
+	var res []goodComics
+	for id, v := range comics {
+		var numOfWords int
+		for _, word := range input {
+			if slices.Contains(v.Keywords, word) {
+				numOfWords++
+			}
+		}
+		res = append(res, goodComics{id: id, numOfKeywords: numOfWords})
+	}
+	slices.SortFunc(res, func(a, b goodComics) int {
+		return cmp.Compare(a.numOfKeywords, b.numOfKeywords) * (-1)
+	})
+	return res
+}
+
+func findByIndex(index map[string][]int, input []string) []goodComics {
+	wasFound := make(map[int]int)
+	for _, keywords := range input {
+		for _, comicsID := range index[keywords] {
+			wasFound[comicsID]++
+		}
+	}
+	var res []goodComics
+	for k, v := range wasFound {
+		res = append(res, goodComics{id: k, numOfKeywords: v})
+	}
+	slices.SortFunc(res, func(a, b goodComics) int {
+		return cmp.Compare(a.numOfKeywords, b.numOfKeywords) * (-1)
+	})
+	return res
+}
+
+// TODO: descript
+type goodComics struct {
+	id            int
+	numOfKeywords int
+}

--- a/cmd/xkcd/find_test.go
+++ b/cmd/xkcd/find_test.go
@@ -1,0 +1,45 @@
+package main
+
+import (
+	"courses/internal/core"
+	"courses/internal/database"
+	"courses/internal/xkcd"
+	"slices"
+	"strings"
+	"testing"
+)
+
+func BenchmarkFindByIndex(b *testing.B) {
+	conf, _ := newConfig("../../config.yaml")
+
+	myDB := database.NewDB(conf.DBFile)
+
+	comics, _ := myDB.Read()
+	if comics == nil {
+		comics = make(map[int]core.ComicsDescript, 3000)
+	}
+	downloader := xkcd.NewComicsDownloader(conf.SourceUrl)
+
+	comics, _ = fillMissedComics(5, comics, myDB, downloader)
+
+	index := make(map[string][]int)
+	var doc []string
+	for k, v := range comics {
+		doc = slices.Concat(doc, v.Keywords)
+		for i, token := range v.Keywords {
+			if !slices.Contains(v.Keywords[:i], token) {
+				index[token] = append(index[token], k)
+			}
+		}
+	}
+	b.Run("findByIndex", func(b *testing.B) {
+		for i := 0; i < b.N; i++ {
+			findByIndex(index, strings.Split("my favorite comics is about unknown mystery person", " "))
+		}
+	})
+	b.Run("findByComics", func(b *testing.B) {
+		for i := 0; i < b.N; i++ {
+			findByComics(comics, strings.Split("my favorite comics is about unknown mystery person", " "))
+		}
+	})
+}

--- a/cmd/xkcd/find_test.go
+++ b/cmd/xkcd/find_test.go
@@ -5,11 +5,12 @@ import (
 	"courses/internal/database"
 	"courses/internal/xkcd"
 	"slices"
+	"strconv"
 	"strings"
 	"testing"
 )
 
-func BenchmarkFindByIndex(b *testing.B) {
+func BenchmarkDiffMethToSearch(b *testing.B) {
 	conf, _ := newConfig("../../config.yaml")
 
 	myDB := database.NewDB(conf.DBFile)
@@ -32,14 +33,21 @@ func BenchmarkFindByIndex(b *testing.B) {
 			}
 		}
 	}
-	b.Run("findByIndex", func(b *testing.B) {
-		for i := 0; i < b.N; i++ {
-			findByIndex(index, strings.Split("my favorite comics is about unknown mystery person", " "))
-		}
-	})
-	b.Run("findByComics", func(b *testing.B) {
-		for i := 0; i < b.N; i++ {
-			findByComics(comics, strings.Split("my favorite comics is about unknown mystery person", " "))
-		}
-	})
+	testString := []string{"my favorite comics is about unknown mystery person", "idk what comics to search",
+		"cool banana man", "orange box sits under that orange table and takes orange to make orange juice",
+		"funny comics about math"}
+	for _, str := range testString {
+		comicsName := "findByIndex-" + strconv.Itoa(len(str))
+		b.Run(comicsName, func(b *testing.B) {
+			for i := 0; i < b.N; i++ {
+				findByIndex(index, strings.Split(str, " "))
+			}
+		})
+		comicsName = "findByComics-" + strconv.Itoa(len(str))
+		b.Run(comicsName, func(b *testing.B) {
+			for i := 0; i < b.N; i++ {
+				findByComics(comics, strings.Split(str, " "))
+			}
+		})
+	}
 }

--- a/cmd/xkcd/main.go
+++ b/cmd/xkcd/main.go
@@ -5,9 +5,11 @@ import (
 	"courses/internal/database"
 	"courses/internal/xkcd"
 	"courses/pkg/words"
+	"encoding/json"
 	"flag"
 	"fmt"
 	"log"
+	"os"
 	"slices"
 	"strings"
 )
@@ -71,6 +73,16 @@ func main() {
 			}
 		}
 	}
+	file, err := json.MarshalIndent(index, "", " ")
+	if err != nil {
+		log.Println(err)
+	}
+
+	err = os.WriteFile("index.json", file, 0644)
+	if err != nil {
+		log.Println(err)
+	}
+
 	var res []goodComics
 	if byIndex {
 		res = findByIndex(index, clearedInput)

--- a/cmd/xkcd/main.go
+++ b/cmd/xkcd/main.go
@@ -68,15 +68,40 @@ func main() {
 	}
 
 	index := make(map[string][]int)
+	var doc []string
 	for k, v := range comics {
-		for _, token := range v.Keywords {
-			index[token] = append(index[token], k)
+		doc = slices.Concat(doc, v.Keywords)
+		for i, token := range v.Keywords {
+			if !slices.Contains(v.Keywords[:i], token) {
+				index[token] = append(index[token], k)
+			}
 		}
 	}
 	res := findByIndex(index, clearedInput)
-	for i := 0; i < min(len(res), 10); i++ {
+	for i := 0; i < min(10, len(res)); i++ {
 		fmt.Println(res[i], comics[res[i].id].Url)
 	}
+	res = findByComics(comics, clearedInput)
+	for i := 0; i < min(10, len(res)); i++ {
+		fmt.Println(res[i], comics[res[i].id].Url)
+	}
+}
+
+func findByComics(comics map[int]core.ComicsDescript, input []string) []goodComics {
+	var res []goodComics
+	for id, v := range comics {
+		var numOfWords int
+		for _, word := range input {
+			if slices.Contains(v.Keywords, word) {
+				numOfWords++
+			}
+		}
+		res = append(res, goodComics{id: id, numOfKeywords: numOfWords})
+	}
+	slices.SortFunc(res, func(a, b goodComics) int {
+		return cmp.Compare(a.numOfKeywords, b.numOfKeywords) * (-1)
+	})
+	return res
 }
 
 func findByIndex(index map[string][]int, input []string) []goodComics {

--- a/cmd/xkcd/main.go
+++ b/cmd/xkcd/main.go
@@ -1,24 +1,16 @@
 package main
 
 import (
-	"cmp"
 	"courses/internal/core"
 	"courses/internal/database"
 	"courses/internal/xkcd"
 	"courses/pkg/words"
 	"flag"
 	"fmt"
-	"gopkg.in/yaml.v3"
 	"log"
-	"os"
 	"slices"
 	"strings"
 )
-
-type Config struct {
-	SourceUrl string `yaml:"source_url"`
-	DBFile    string `yaml:"db_file"`
-}
 
 type comicsDescriptWithID struct {
 	core.ComicsDescript
@@ -88,81 +80,4 @@ func main() {
 	for i := 0; i < min(10, len(res)); i++ {
 		fmt.Println(res[i], comics[res[i].id].Url)
 	}
-}
-
-func findByComics(comics map[int]core.ComicsDescript, input []string) []goodComics {
-	var res []goodComics
-	for id, v := range comics {
-		var numOfWords int
-		for _, word := range input {
-			if slices.Contains(v.Keywords, word) {
-				numOfWords++
-			}
-		}
-		res = append(res, goodComics{id: id, numOfKeywords: numOfWords})
-	}
-	slices.SortFunc(res, func(a, b goodComics) int {
-		return cmp.Compare(a.numOfKeywords, b.numOfKeywords) * (-1)
-	})
-	return res
-}
-
-func findByIndex(index map[string][]int, input []string) []goodComics {
-	wasFound := make(map[int]int)
-	for _, keywords := range input {
-		for _, comicsID := range index[keywords] {
-			wasFound[comicsID]++
-		}
-	}
-	var res []goodComics
-	for k, v := range wasFound {
-		res = append(res, goodComics{id: k, numOfKeywords: v})
-	}
-	slices.SortFunc(res, func(a, b goodComics) int {
-		return cmp.Compare(a.numOfKeywords, b.numOfKeywords) * (-1)
-	})
-	return res
-}
-
-type goodComics struct {
-	id            int
-	numOfKeywords int
-}
-
-func newConfig(configPath string) (*Config, error) {
-	config := &Config{}
-
-	file, err := os.Open(configPath)
-	if err != nil {
-		return nil, err
-	}
-	defer func(file *os.File) {
-		_ = file.Close()
-	}(file)
-
-	d := yaml.NewDecoder(file)
-	if err = d.Decode(&config); err != nil {
-		return nil, err
-	}
-
-	return config, nil
-}
-
-func getGoroutinesNum() (int, error) {
-	defaultValue := 500
-	obj := make(map[string]int)
-
-	yamlFile, err := os.ReadFile("parallel")
-	if err != nil {
-		return defaultValue, err
-	}
-	err = yaml.Unmarshal(yamlFile, obj)
-	if err != nil {
-		return defaultValue, err
-	}
-
-	if obj["goroutines"] == 0 {
-		obj["goroutines"] = defaultValue
-	}
-	return obj["goroutines"], nil
 }

--- a/cmd/xkcd/main.go
+++ b/cmd/xkcd/main.go
@@ -29,8 +29,7 @@ func main() {
 	flag.BoolVar(&byIndex, "i", false, "find comics by index")
 	flag.Parse()
 	if inputString == "" {
-		// TODO
-		log.Println("empty input")
+		log.Println("Input string shouldn't be empty")
 	}
 	clearedInput := words.StemStringWithClearing(strings.Split(inputString, " "))
 

--- a/cmd/xkcd/main.go
+++ b/cmd/xkcd/main.go
@@ -31,6 +31,8 @@ func main() {
 	flag.StringVar(&configPath, "c", "config.yaml", "path to config.yml file")
 	var inputString string
 	flag.StringVar(&inputString, "s", "", "string to find")
+	var byIndex bool
+	flag.BoolVar(&byIndex, "i", false, "find comics by index")
 	flag.Parse()
 	if inputString == "" {
 		// TODO
@@ -77,11 +79,12 @@ func main() {
 			}
 		}
 	}
-	res := findByIndex(index, clearedInput)
-	for i := 0; i < min(10, len(res)); i++ {
-		fmt.Println(res[i], comics[res[i].id].Url)
+	var res []goodComics
+	if byIndex {
+		res = findByIndex(index, clearedInput)
+	} else {
+		res = findByComics(comics, clearedInput)
 	}
-	res = findByComics(comics, clearedInput)
 	for i := 0; i < min(10, len(res)); i++ {
 		fmt.Println(res[i], comics[res[i].id].Url)
 	}

--- a/go.mod
+++ b/go.mod
@@ -8,4 +8,4 @@ require (
 	github.com/toadharvard/stopwords-iso v0.1.5
 )
 
-require gopkg.in/yaml.v3 v3.0.1 // indirect
+require gopkg.in/yaml.v3 v3.0.1

--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,7 @@ go 1.22.0
 require (
 	github.com/kljensen/snowball v0.9.0
 	github.com/tebeka/snowball v0.7.0
-	github.com/toadharvard/stopwords-iso v0.1.2
+	github.com/toadharvard/stopwords-iso v0.1.5
 )
 
 require gopkg.in/yaml.v3 v3.0.1 // indirect

--- a/go.sum
+++ b/go.sum
@@ -10,6 +10,8 @@ github.com/tebeka/snowball v0.7.0 h1:4kx0zZ2Pg8r73RiY/CnGEydwN9hN4nG2HqSdH67zxcA
 github.com/tebeka/snowball v0.7.0/go.mod h1:L1/aiWo8AlJe9batdXfKIQeaxIYzlaTveYvGPuMu76Q=
 github.com/toadharvard/stopwords-iso v0.1.2 h1:y4ddNmueT4cdQ8W/CuPfLlfmnSujIoNCzI8X0QCmFiI=
 github.com/toadharvard/stopwords-iso v0.1.2/go.mod h1:r5uaUKI3yJDZ8XY5SbTnRVfo5lcEfwYLUHkdlgXc/Yk=
+github.com/toadharvard/stopwords-iso v0.1.5 h1:2PhE7ffmeXwH4PEU2fegfb/3SiT3FiyzBO4RFvPcC0I=
+github.com/toadharvard/stopwords-iso v0.1.5/go.mod h1:r5uaUKI3yJDZ8XY5SbTnRVfo5lcEfwYLUHkdlgXc/Yk=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=
 gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=

--- a/go.sum
+++ b/go.sum
@@ -1,5 +1,7 @@
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/dkgv/go-tf-idf v0.0.0-20220422104447-dad26aa7b2f4 h1:LVflKaR4eDpf1SwMm8NBXz4+r1hBbunYGH0TS6s/UO8=
+github.com/dkgv/go-tf-idf v0.0.0-20220422104447-dad26aa7b2f4/go.mod h1:TR7ixrWRoZr4jw8MDQr+3sOUO/pS8w/+5SzPtPn4H1Y=
 github.com/kljensen/snowball v0.9.0 h1:OpXkQBcic6vcPG+dChOGLIA/GNuVg47tbbIJ2s7Keas=
 github.com/kljensen/snowball v0.9.0/go.mod h1:OGo5gFWjaeXqCu4iIrMl5OYip9XUJHGOU5eSkPjVg2A=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
@@ -8,10 +10,9 @@ github.com/stretchr/testify v1.8.1 h1:w7B6lhMri9wdJUVmEZPGGhZzrYTPvgJArz7wNPgYKs
 github.com/stretchr/testify v1.8.1/go.mod h1:w2LPCIKwWwSfY2zedu0+kehJoqGctiVI29o6fzry7u4=
 github.com/tebeka/snowball v0.7.0 h1:4kx0zZ2Pg8r73RiY/CnGEydwN9hN4nG2HqSdH67zxcA=
 github.com/tebeka/snowball v0.7.0/go.mod h1:L1/aiWo8AlJe9batdXfKIQeaxIYzlaTveYvGPuMu76Q=
-github.com/toadharvard/stopwords-iso v0.1.2 h1:y4ddNmueT4cdQ8W/CuPfLlfmnSujIoNCzI8X0QCmFiI=
-github.com/toadharvard/stopwords-iso v0.1.2/go.mod h1:r5uaUKI3yJDZ8XY5SbTnRVfo5lcEfwYLUHkdlgXc/Yk=
 github.com/toadharvard/stopwords-iso v0.1.5 h1:2PhE7ffmeXwH4PEU2fegfb/3SiT3FiyzBO4RFvPcC0I=
 github.com/toadharvard/stopwords-iso v0.1.5/go.mod h1:r5uaUKI3yJDZ8XY5SbTnRVfo5lcEfwYLUHkdlgXc/Yk=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=
 gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=

--- a/pkg/words/stemmer.go
+++ b/pkg/words/stemmer.go
@@ -21,18 +21,5 @@ func stemSingleLanguage(myStemmer stemmer, input []string, language string) []st
 			res = append(res, newStr)
 		}
 	}
-	return removeDuplicateStrings(res)
-}
-
-func removeDuplicateStrings(strings []string) []string {
-	var list []string
-	keys := make(map[string]bool)
-
-	for _, str := range strings {
-		if _, value := keys[str]; !value {
-			keys[str] = true
-			list = append(list, str)
-		}
-	}
-	return list
+	return res
 }

--- a/pkg/words/utils.go
+++ b/pkg/words/utils.go
@@ -10,9 +10,9 @@ import (
 // List of words probably will be changed
 func clearInputFromStopWords(inputString []string) []string {
 	var clearedStrings []string
-	stopwordsMapping, _ := sw.NewStopwordsMapping()
+	stopWordsMapping, _ := sw.NewStopwordsMapping()
 	for _, str := range inputString {
-		newStr := stopwordsMapping.ClearString(str)
+		newStr := stopWordsMapping.ClearString(str)
 		if newStr != "" {
 			clearedStrings = append(clearedStrings, newStr)
 		}

--- a/pkg/words/utils.go
+++ b/pkg/words/utils.go
@@ -2,20 +2,37 @@ package words
 
 import (
 	sw "github.com/toadharvard/stopwords-iso"
+	"regexp"
+	"strings"
 )
 
-// clearInputFromStopWords based on list of words from
-// https://github.com/toadharvard/stopwords-iso/
+// clearInput removes stopwords and marks as "'", "?", "-".
+// stopwords cleaner based on https://github.com/toadharvard/stopwords-iso/
 //
 // List of words probably will be changed
-func clearInputFromStopWords(inputString []string) []string {
-	var clearedStrings []string
+func clearInput(inputString []string) []string {
+	joinedString := strings.Join(inputString, " ")
+	tokenizedString := tokenize(joinedString)
+
 	stopWordsMapping, _ := sw.NewStopwordsMapping()
-	for _, str := range inputString {
+	var clearedString []string
+
+	for _, str := range tokenizedString {
 		newStr := stopWordsMapping.ClearString(str)
-		if newStr != "" {
-			clearedStrings = append(clearedStrings, newStr)
+		if len(newStr) > 2 {
+			clearedString = append(clearedString, newStr)
 		}
 	}
-	return clearedStrings
+	return clearedString
+}
+
+func tokenize(str string) []string {
+	wordSegmenter := regexp.MustCompile(`[\pL\p{Mc}\p{Mn}-_']+`)
+	alphanumericOnly := regexp.MustCompile(`[^\p{L}\p{N} ]+`)
+	words := strings.Fields(str)
+	splitted := strings.Join(words, " ")
+
+	onlyAlphanumeric := alphanumericOnly.ReplaceAllString(splitted, " ")
+	words = wordSegmenter.FindAllString(onlyAlphanumeric, -1)
+	return words
 }

--- a/pkg/words/words.go
+++ b/pkg/words/words.go
@@ -7,14 +7,12 @@ import (
 // StemStringWithClearing gets string, clears from most popular words and returns slice of keys
 func StemStringWithClearing(input []string) []string {
 
-	var cleanInput = clearInputFromStopWords(input)
-
+	var cleanInput = clearInput(input)
 	snowballStemmer := func(input string, language string) (string, error) {
 		return snowball.Stem(input, language, false)
 	}
 
 	var setOfLanguages = []string{"english", "russian"}
 	result := stemInMultipleLanguages(snowballStemmer, cleanInput, setOfLanguages)
-
 	return result
 }


### PR DESCRIPTION
#7 

## xkcd

Вынес в отдельные файлы часть функциональности (поиск по индексу и без, получение конфигурации, заполнение недостающих комиксов)

## Поиск

На данный момент самым подходящим комиксом считается тот, в котором встречается наибольшее число ключевых слов. Планирую добавить ранжирование с помощью [tf-idf](https://en.wikipedia.org/wiki/Tf%E2%80%93idf). Некоторая проблема с тем, что под го не нашел нормальную библиотеку (или не смог нормально воспользоваться, еще узнаю).

## Бенчмарки

Способы поиска тестируются на 5ти строках (числа в названиях бенча -- длина строки)

![image](https://github.com/vacmannnn/golang-courses/assets/111463436/a812a02d-bf32-4231-b670-52283159a85c)
Поиск по индексу существенно (в 60-100 раз) быстрее поиска по комиксам. При этом скорость поиска может сильно возрастать на различных строках вне зависимости от способа поиска (случаи с 3600ns и 69000ns)

## Вопросы
- стоит ли выносить какую-то часть функциональности в отдельные пакеты ?
- нужен ли будет в дальнейшем файл `index.json` ? Пока что не вижу смысла в нем особого, кроме "отладки" ключевых слов. Так же заметил, благодаря файлу, что очистка слов работает криво (есть _очень_ много мусорных слов, по типу `'a`, `'i`, `------` и подобных)

## TODO:
- [x] дописать бенчмарки
- [ ] реализовать ранжирование через tf-idf
- [x] пофиксить очистку слов
- [x] переделать обработку сигналов, сейчас ctrl-c не помогает остановить программу