### PR TITLE
json -> sqlite

### DIFF
--- a/cmd/xkcd/main.go
+++ b/cmd/xkcd/main.go
@@ -12,6 +12,7 @@ import (
 	"fmt"
 	"github.com/robfig/cron/v3"
 	"io"
+	"log"
 	"log/slog"
 	"net/http"
 	"os"
@@ -40,7 +41,11 @@ func main() {
 	}
 
 	// read existed DB to simplify downloading
-	myDB := database.NewDB(conf.DBFile)
+	myDB, err := database.NewDB(conf.DBFile)
+	if err != nil {
+		log.Fatal(err)
+	}
+	defer myDB.Close()
 
 	comics, err := myDB.Read()
 	if comics == nil {

--- a/cmd/xkcd/main.go
+++ b/cmd/xkcd/main.go
@@ -8,7 +8,6 @@ import (
 	"courses/internal/core/filler"
 	"courses/internal/core/xkcd"
 	"courses/internal/database"
-	"encoding/json"
 	"fmt"
 	"github.com/robfig/cron/v3"
 	"io"
@@ -68,18 +67,6 @@ func main() {
 
 	// build index
 	ctlg := catalog.NewCatalog(comics, comicsFiller)
-	index := ctlg.GetIndex()
-
-	// write to index.json
-	file, err := json.MarshalIndent(index, "", " ")
-	if err != nil {
-		logger.Warn(err.Error())
-	}
-
-	err = os.WriteFile("index.json", file, 0644)
-	if err != nil {
-		logger.Warn(err.Error())
-	}
 
 	mux := handler.CreateServeMux(ctlg, logger)
 	portStr := fmt.Sprintf(":%d", port)

--- a/config.yaml
+++ b/config.yaml
@@ -2,7 +2,7 @@ source_url:
   "https://xkcd.com"
 
 db_file:
-  "database.json"
+  "database.sql"
 
 port:
   8080

--- a/go.mod
+++ b/go.mod
@@ -9,6 +9,7 @@ require (
 )
 
 require (
+	github.com/mattn/go-sqlite3 v1.14.22
 	github.com/robfig/cron/v3 v3.0.1
 	gopkg.in/yaml.v3 v3.0.1
 )

--- a/go.mod
+++ b/go.mod
@@ -9,6 +9,7 @@ require (
 )
 
 require (
+	github.com/golang-migrate/migrate v3.5.4+incompatible
 	github.com/mattn/go-sqlite3 v1.14.22
 	github.com/robfig/cron/v3 v3.0.1
 	gopkg.in/yaml.v3 v3.0.1

--- a/go.sum
+++ b/go.sum
@@ -1,5 +1,7 @@
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/golang-migrate/migrate v3.5.4+incompatible h1:R7OzwvCJTCgwapPCiX6DyBiu2czIUMDCB118gFTKTUA=
+github.com/golang-migrate/migrate v3.5.4+incompatible/go.mod h1:IsVUlFN5puWOmXrqjgGUfIRIbU7mr8oNBE2tyERd9Wk=
 github.com/kljensen/snowball v0.9.0 h1:OpXkQBcic6vcPG+dChOGLIA/GNuVg47tbbIJ2s7Keas=
 github.com/kljensen/snowball v0.9.0/go.mod h1:OGo5gFWjaeXqCu4iIrMl5OYip9XUJHGOU5eSkPjVg2A=
 github.com/mattn/go-sqlite3 v1.14.22 h1:2gZY6PC6kBnID23Tichd1K+Z0oS6nE/XwU+Vz/5o4kU=

--- a/go.sum
+++ b/go.sum
@@ -2,6 +2,8 @@ github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/kljensen/snowball v0.9.0 h1:OpXkQBcic6vcPG+dChOGLIA/GNuVg47tbbIJ2s7Keas=
 github.com/kljensen/snowball v0.9.0/go.mod h1:OGo5gFWjaeXqCu4iIrMl5OYip9XUJHGOU5eSkPjVg2A=
+github.com/mattn/go-sqlite3 v1.14.22 h1:2gZY6PC6kBnID23Tichd1K+Z0oS6nE/XwU+Vz/5o4kU=
+github.com/mattn/go-sqlite3 v1.14.22/go.mod h1:Uh1q+B4BYcTPb+yiD3kU8Ct7aC0hY9fxUwlHK0RXw+Y=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/robfig/cron/v3 v3.0.1 h1:WdRxkvbJztn8LMz/QEvLN5sBU+xKpSqwwUO1Pjr4qDs=

--- a/internal/core/catalog/catalog.go
+++ b/internal/core/catalog/catalog.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"courses/internal/core"
 	"courses/internal/core/filler"
-	"fmt"
 	"maps"
 	"reflect"
 	"slices"
@@ -51,7 +50,6 @@ func (c *ComicsCatalog) UpdateComics() (map[string]int, error) {
 
 	eq := reflect.DeepEqual(updatedComics, oldComics)
 	var n int
-	fmt.Println(eq, len(updatedComics), len(oldComics))
 	if !eq {
 		for k, v := range updatedComics {
 			if !slices.Equal(oldComics[k].Keywords, v.Keywords) {

--- a/internal/core/catalog/find.go
+++ b/internal/core/catalog/find.go
@@ -13,10 +13,10 @@ type goodComics struct {
 
 // FindByIndex searches input string by its slice of keywords and returns slice of most suitable comics URLs. The more
 // comics suitable, the lower the index
-func (f *ComicsCatalog) FindByIndex(input []string) []string {
+func (c *ComicsCatalog) FindByIndex(input []string) []string {
 	wasFound := make(map[int]int)
 	for _, keywords := range input {
-		for _, comicsID := range f.index[keywords] {
+		for _, comicsID := range c.index[keywords] {
 			wasFound[comicsID]++
 		}
 	}
@@ -31,15 +31,15 @@ func (f *ComicsCatalog) FindByIndex(input []string) []string {
 	})
 	var urls []string
 	for i := 0; i < min(core.MaxComicsToShow, len(res)); i++ {
-		urls = append(urls, f.comics[res[i].Id].Url)
+		urls = append(urls, c.comics[res[i].Id].Url)
 	}
 	return urls
 }
 
 // findByComics unused cause of inefficient speed compared to FindByIndex
-func (f *ComicsCatalog) findByComics(input []string) []string {
+func (c *ComicsCatalog) findByComics(input []string) []string {
 	var res []goodComics
-	for id, v := range f.comics {
+	for id, v := range c.comics {
 		var numOfWords int
 		for _, word := range input {
 			if slices.Contains(v.Keywords, word) {
@@ -55,7 +55,7 @@ func (f *ComicsCatalog) findByComics(input []string) []string {
 	})
 	var urls []string
 	for i := 0; i < min(core.MaxComicsToShow, len(res)); i++ {
-		urls = append(urls, f.comics[res[i].Id].Url)
+		urls = append(urls, c.comics[res[i].Id].Url)
 	}
 	return urls
 }

--- a/internal/core/catalog/find_test.go
+++ b/internal/core/catalog/find_test.go
@@ -15,7 +15,7 @@ import (
 )
 
 func BenchmarkDiffMethToSearch(b *testing.B) {
-	myDB := database.NewDB("test.json")
+	myDB, _ := database.NewDB("test.json")
 
 	comics, _ := myDB.Read()
 	if comics == nil {

--- a/internal/core/core.go
+++ b/internal/core/core.go
@@ -12,7 +12,7 @@ type ComicsDownloader interface {
 }
 
 type DataBase interface {
-	Write(map[int]ComicsDescript) error
+	Write(ComicsDescript, int) error
 	Read() (map[int]ComicsDescript, error)
 }
 

--- a/internal/database/database.go
+++ b/internal/database/database.go
@@ -95,10 +95,10 @@ func (d *DataBase) Read() (map[int]core.ComicsDescript, error) {
 	comics := make(map[int]core.ComicsDescript)
 
 	for rows.Next() {
-		var abc, id int
+		var id int
 		var keywords string
 		descript := core.ComicsDescript{}
-		err = rows.Scan(&abc, &descript.Url, &keywords, &id)
+		err = rows.Scan(&descript.Url, &keywords, &id)
 		if err != nil {
 			fmt.Println(err)
 			continue

--- a/internal/database/migration/001_comix_table.down.sql
+++ b/internal/database/migration/001_comix_table.down.sql
@@ -1,0 +1,1 @@
+DROP TABLE comics;

--- a/internal/database/migration/001_comix_table.up.sql
+++ b/internal/database/migration/001_comix_table.up.sql
@@ -1,0 +1,6 @@
+CREATE TABLE comics (
+  id INTEGER NOT NULL PRIMARY KEY,
+  url TEXT,
+  keywords TEXT,
+  comicsID INTEGER
+);

--- a/internal/database/migration/001_comix_table.up.sql
+++ b/internal/database/migration/001_comix_table.up.sql
@@ -1,6 +1,5 @@
 CREATE TABLE comics (
-  id INTEGER NOT NULL PRIMARY KEY,
   url TEXT,
   keywords TEXT,
-  comicsID INTEGER
+  comicsID INTEGER NOT NULL PRIMARY KEY
 );


### PR DESCRIPTION
#11 

Решил немного упростить задачу, но готов обсудить минусы такого подхода. Также пофиксил пару багов с предудщих задач.

## Таблица для индекса

Не вижу смысла в ее хранении (с практической точки зрения) на диске, поэтому она создается во время запуска и хранится только в оперативке. Ее хранение было полезно в 4й задаче и помогло обнаружить кучу дыр в стеммере, сейчас, кажется, от этого нет такого профита.

## Упрощение БД для комиксов и ее загрузка в оперативку

Т.к. база данных слишком маленькая (~3000 записей и чуть меньше 1мб веса), есть смысл загружать ее сразу в оперативку для упрощения логики программы и ускорения работы.

Бенчмарки для проверки реальной разницы (sql vs json и "загрузка всей БД" vs "запросы отдельных комиксов") планирую написать позже (скорее всего в пределах 8й недели с заданиями на тесты), но уже можно предположить разницу с помощью таблицы ["Latency numbers every programmer should know"](https://gist.github.com/hellerbarde/2843375):

- Main memory reference ...................... 100 ns
- SSD random read ........................ 150,000 ns  = 150 µs

_P.s. не удивлюсь, если окажется, что для общей оптимизации даже при "одиночном" чтении комикса в оперативку будет загружаться вся БД_

![image](https://github.com/vacmannnn/golang-courses/assets/111463436/2c9e8ee2-f69a-4122-8e2b-719ab3d9ce1a)

